### PR TITLE
Add folder-preserving imports and folder categories

### DIFF
--- a/Wardrobe/Models/ImageRecord.swift
+++ b/Wardrobe/Models/ImageRecord.swift
@@ -31,6 +31,10 @@ final class ImageRecord {
     var customTags: [String] = []
     /// User-assigned notes or descriptions.
     var notes: String?
+    /// Relative path of the source file inside a user-imported directory.
+    var sourceRelativePath: String?
+    /// Top-level folder name from the source import directory, used for folder categories.
+    var sourceTopLevelFolder: String?
     /// HTTP/HTTPS URLs detected within the OCR text via `NSDataDetector`.
     var detectedURLs: [String] = []
     /// Automated tags generated via Apple's Vision Image Classification framework.
@@ -50,6 +54,8 @@ final class ImageRecord {
     ///   - textEmbedding: Semantic vector array.
     ///   - customTags: User tags.
     ///   - notes: User notes.
+    ///   - sourceRelativePath: Relative source path in imported directory.
+    ///   - sourceTopLevelFolder: Top-level source folder name.
     ///   - detectedURLs: Parsed hyperlinks.
     ///   - smartTags: Vision image classifications.
     ///   - featurePrintData: Vision feature print for duplicate matching.
@@ -63,6 +69,8 @@ final class ImageRecord {
         textEmbedding: [Double]? = nil,
         customTags: [String] = [],
         notes: String? = nil,
+        sourceRelativePath: String? = nil,
+        sourceTopLevelFolder: String? = nil,
         detectedURLs: [String] = [],
         smartTags: [String] = [],
         featurePrintData: Data? = nil,
@@ -76,6 +84,8 @@ final class ImageRecord {
         self.textEmbedding = textEmbedding
         self.customTags = customTags
         self.notes = notes
+        self.sourceRelativePath = sourceRelativePath
+        self.sourceTopLevelFolder = sourceTopLevelFolder
         self.detectedURLs = detectedURLs
         self.smartTags = smartTags
         self.featurePrintData = featurePrintData

--- a/Wardrobe/Services/StorageManager.swift
+++ b/Wardrobe/Services/StorageManager.swift
@@ -8,6 +8,13 @@
 import Foundation
 import UniformTypeIdentifiers
 
+struct ImportedImage {
+    let originalURL: URL
+    let copiedURL: URL
+    let sourceRelativePath: String
+    let sourceTopLevelFolder: String?
+}
+
 /// A background actor responsible for safely managing the local file system.
 ///
 /// `StorageManager` ensures that images dropped into the app are safely copied
@@ -87,6 +94,69 @@ actor StorageManager {
         return destinationURL
     }
     
+    /// Recursively imports all image files from a directory into the app-managed library,
+    /// preserving each file's relative folder hierarchy under an import-specific root.
+    ///
+    /// - Parameter directoryURL: User-selected source directory.
+    /// - Returns: Imported image descriptors including copied file URL and source folder metadata.
+    /// - Throws: `StorageError` if directory enumeration or file copy fails.
+    func importImages(fromDirectory directoryURL: URL) throws -> [ImportedImage] {
+        guard let imagesDirectory else {
+            throw StorageError.directoryNotAvailable
+        }
+        
+        let fileManager = FileManager.default
+        let rootName = directoryURL.lastPathComponent
+        let importFolderName = "import_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(6))_\(rootName)"
+        let importRootURL = imagesDirectory.appendingPathComponent(importFolderName, isDirectory: true)
+        try fileManager.createDirectory(at: importRootURL, withIntermediateDirectories: true, attributes: nil)
+        
+        guard let enumerator = fileManager.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentTypeKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            throw StorageError.enumerationFailed(directoryURL.path)
+        }
+        
+        var importedImages: [ImportedImage] = []
+        
+        for case let itemURL as URL in enumerator {
+            let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey])
+            if resourceValues.isDirectory == true {
+                continue
+            }
+            
+            guard let contentType = resourceValues.contentType, contentType.conforms(to: .image) else {
+                continue
+            }
+            
+            let relativePath = itemURL.path.replacingOccurrences(of: directoryURL.path + "/", with: "")
+            let destinationURL = importRootURL.appendingPathComponent(relativePath)
+            let destinationDirectory = destinationURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: destinationDirectory, withIntermediateDirectories: true, attributes: nil)
+            try fileManager.copyItem(at: itemURL, to: destinationURL)
+            
+            let relativeComponents = relativePath.split(separator: "/")
+            let topLevelFolder: String?
+            if relativeComponents.count > 1 {
+                topLevelFolder = String(relativeComponents[0])
+            } else {
+                topLevelFolder = rootName
+            }
+            importedImages.append(
+                ImportedImage(
+                    originalURL: itemURL,
+                    copiedURL: destinationURL,
+                    sourceRelativePath: relativePath,
+                    sourceTopLevelFolder: topLevelFolder
+                )
+            )
+        }
+        
+        return importedImages
+    }
+    
     /// Permanently deletes an image file from local disk storage.
     ///
     /// - Parameter url: The absolute URL of the file to remove.
@@ -108,6 +178,7 @@ enum StorageError: Error, LocalizedError {
     case directoryNotAvailable
     case fileNotFound
     case copyFailed(Error)
+    case enumerationFailed(String)
     case unknown
     
     var errorDescription: String? {
@@ -118,6 +189,8 @@ enum StorageError: Error, LocalizedError {
             return "Image file not found"
         case .copyFailed(let error):
             return "Failed to copy image: \(error.localizedDescription)"
+        case .enumerationFailed(let path):
+            return "Failed to enumerate directory: \(path)"
         case .unknown:
             return "An unknown error occurred"
         }

--- a/Wardrobe/Views/CollectionsView.swift
+++ b/Wardrobe/Views/CollectionsView.swift
@@ -15,18 +15,53 @@ struct CollectionsView: View {
     @Query(sort: \ImageCollection.dateCreated, order: .reverse) private var userCollections: [ImageCollection]
     
     @State private var selectedSmart: SmartCollection?
+    @State private var selectedFolderCategory: String?
     @State private var selectedUser: ImageCollection?
     @State private var previewImage: ImageRecord?
     @State private var showingNewCollectionSheet = false
     
+    private struct FolderCategory: Identifiable {
+        let name: String
+        let images: [ImageRecord]
+        
+        var id: String { name }
+        var count: Int { images.count }
+    }
+    
     private func imagesIn(_ collection: SmartCollection) -> [ImageRecord] {
         allImages.filter { collection.matches(date: $0.dateAdded) }
+    }
+    
+    private var folderCategories: [FolderCategory] {
+        let grouped = Dictionary(grouping: allImages) { image -> String? in
+            if let folder = image.sourceTopLevelFolder, !folder.isEmpty {
+                return folder
+            }
+            if let relativePath = image.sourceRelativePath, !relativePath.isEmpty {
+                return relativePath.split(separator: "/").first.map(String.init)
+            }
+            return nil
+        }
+        
+        return grouped
+            .compactMap { key, value in
+                guard let key else { return nil }
+                return FolderCategory(name: key, images: value.sorted { $0.dateAdded > $1.dateAdded })
+            }
+            .sorted { lhs, rhs in
+                if lhs.count == rhs.count {
+                    return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                }
+                return lhs.count > rhs.count
+            }
     }
     
     var body: some View {
         VStack(spacing: 0) {
             if let smart = selectedSmart {
                 smartCollectionDetailView(for: smart)
+            } else if let folderName = selectedFolderCategory {
+                folderCategoryDetailView(for: folderName)
             } else if let user = selectedUser {
                 userCollectionDetailView(for: user)
             } else {
@@ -77,6 +112,7 @@ struct CollectionsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 28) {
                     smartCollectionsSection
+                    folderCategoriesSection
                     userCollectionsSection
                 }
                 .padding(24)
@@ -152,12 +188,53 @@ struct CollectionsView: View {
         }
     }
     
+    private var folderCategoriesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("FOLDER CATEGORIES")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(0.5)
+                Spacer()
+            }
+            
+            if folderCategories.isEmpty {
+                HStack(spacing: 10) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.tertiary)
+                    Text("Import a directory to generate categories that respect source folders.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.secondary.opacity(0.06))
+                )
+            } else {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 200, maximum: 260), spacing: 16)],
+                    spacing: 16
+                ) {
+                    ForEach(folderCategories) { category in
+                        folderCategoryTile(category)
+                    }
+                }
+            }
+        }
+    }
+    
     private func smartCollectionTile(_ collection: SmartCollection) -> some View {
         let images = imagesIn(collection)
         let count = images.count
         
         return Button {
             selectedSmart = collection
+            selectedFolderCategory = nil
+            selectedUser = nil
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 ZStack(alignment: .bottomLeading) {
@@ -205,6 +282,8 @@ struct CollectionsView: View {
         
         return Button {
             selectedUser = collection
+            selectedFolderCategory = nil
+            selectedSmart = nil
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 ZStack {
@@ -251,6 +330,56 @@ struct CollectionsView: View {
         }
     }
     
+    private func folderCategoryTile(_ category: FolderCategory) -> some View {
+        let count = category.images.count
+        let themeColor = colorForFolderCategory(category.name)
+        
+        return Button {
+            selectedFolderCategory = category.name
+            selectedSmart = nil
+            selectedUser = nil
+        } label: {
+            VStack(alignment: .leading, spacing: 0) {
+                ZStack {
+                    LinearGradient(
+                        colors: [themeColor, themeColor.opacity(0.75)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    .overlay(
+                        Image(systemName: "folder.fill")
+                            .font(.system(size: 44, weight: .regular))
+                            .foregroundStyle(.white.opacity(0.9))
+                    )
+                }
+                .frame(height: 120)
+                .clipShape(UnevenRoundedRectangle(topLeadingRadius: 10, topTrailingRadius: 10))
+                
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(category.name)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text("\(count) screenshot\(count == 1 ? "" : "s")")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+    
     @ViewBuilder
     private func smartCollectionDetailView(for collection: SmartCollection) -> some View {
         let images = imagesIn(collection)
@@ -286,6 +415,23 @@ struct CollectionsView: View {
                     Label("Remove from \(collection.name)", systemImage: "minus.circle")
                 }
             }
+        )
+    }
+    
+    @ViewBuilder
+    private func folderCategoryDetailView(for folderName: String) -> some View {
+        let images = folderCategories.first(where: { $0.name == folderName })?.images ?? []
+        let folderColor = colorForFolderCategory(folderName)
+        
+        collectionDetailShell(
+            title: folderName,
+            subtitle: "\(images.count) screenshot\(images.count == 1 ? "" : "s")",
+            icon: "folder.fill",
+            gradient: [folderColor, folderColor.opacity(0.7)],
+            onBack: { selectedFolderCategory = nil },
+            images: images,
+            emptyMessage: "Images imported under this source folder appear here automatically.",
+            imageContextMenu: { _ in EmptyView() }
         )
     }
     
@@ -406,6 +552,15 @@ struct CollectionsView: View {
         Task.detached {
             try? FileManager.default.removeItem(at: url)
         }
+    }
+    
+    private func colorForFolderCategory(_ name: String) -> Color {
+        let scalarSum = name.unicodeScalars.reduce(0) { partialResult, scalar in
+            partialResult + Int(scalar.value)
+        }
+        let palette = CollectionPalette.presets
+        let index = scalarSum % palette.count
+        return Color(hex: palette[index].hex) ?? .accentColor
     }
 }
 

--- a/Wardrobe/Views/GalleryView.swift
+++ b/Wardrobe/Views/GalleryView.swift
@@ -29,6 +29,7 @@ struct GalleryView: View {
     @State private var zoomLevel: Double = 200
     @State private var viewMode: GalleryViewMode = .grid
     @State private var isDragTargeted = false
+    @State private var showingDirectoryImporter = false
     
     private var displayImages: [ImageRecord] {
         if searchQuery.isEmpty {
@@ -102,6 +103,13 @@ struct GalleryView: View {
         }
         .sheet(item: $selectedImage) { image in
             ImageDetailView(image: image, onDelete: deleteImage)
+        }
+        .fileImporter(
+            isPresented: $showingDirectoryImporter,
+            allowedContentTypes: [.directory],
+            allowsMultipleSelection: false
+        ) { result in
+            handleDirectoryImport(result: result)
         }
     }
     
@@ -180,6 +188,17 @@ struct GalleryView: View {
     
     private var actionButtons: some View {
         HStack(spacing: 8) {
+            Button {
+                showingDirectoryImporter = true
+            } label: {
+                Image(systemName: "folder.badge.plus")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .help("Import folder")
+            
             Button {
                 // Quick actions
             } label: {
@@ -377,6 +396,69 @@ struct GalleryView: View {
         searchResults = []
     }
     
+    private func handleDirectoryImport(result: Result<[URL], any Error>) {
+        switch result {
+        case .success(let urls):
+            guard let directoryURL = urls.first else { return }
+            importDirectory(directoryURL)
+        case .failure(let error):
+            errorMessage = "Failed to open directory: \(error.localizedDescription)"
+            showingError = true
+        }
+    }
+    
+    private func importDirectory(_ directoryURL: URL) {
+        isProcessing = true
+        
+        Task {
+            do {
+                let importedImages = try await StorageManager.shared.importImages(fromDirectory: directoryURL)
+                guard !importedImages.isEmpty else {
+                    await MainActor.run {
+                        errorMessage = "No image files were found in the selected folder."
+                        showingError = true
+                        isProcessing = false
+                    }
+                    return
+                }
+                
+                for imported in importedImages {
+                    let processed = try await ProcessingService.shared.processImage(at: imported.copiedURL)
+                    
+                    await MainActor.run {
+                        let record = ImageRecord(
+                            filename: imported.copiedURL.lastPathComponent,
+                            fileURL: imported.copiedURL,
+                            extractedText: processed.text.isEmpty ? nil : processed.text,
+                            textEmbedding: processed.embedding,
+                            sourceRelativePath: imported.sourceRelativePath,
+                            sourceTopLevelFolder: imported.sourceTopLevelFolder,
+                            detectedURLs: processed.urls,
+                            smartTags: processed.smartTags,
+                            featurePrintData: processed.featurePrint,
+                            extractedEntities: processed.entities
+                        )
+                        modelContext.insert(record)
+                    }
+                }
+                
+                await MainActor.run {
+                    try? modelContext.save()
+                    isProcessing = false
+                    if !searchQuery.isEmpty {
+                        performSearch()
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = "Failed to import folder: \(error.localizedDescription)"
+                    showingError = true
+                    isProcessing = false
+                }
+            }
+        }
+    }
+    
     private func handleDrop(providers: [NSItemProvider]) {
         guard !providers.isEmpty else { return }
         
@@ -395,6 +477,8 @@ struct GalleryView: View {
                                 fileURL: fileURL,
                                 extractedText: extractedText.isEmpty ? nil : extractedText,
                                 textEmbedding: embedding,
+                                sourceRelativePath: nil,
+                                sourceTopLevelFolder: nil,
                                 detectedURLs: detectedURLs,
                                 smartTags: smartTags,
                                 featurePrintData: featurePrint,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add directory import support that copies image trees into the app-managed library while preserving relative folder hierarchy
- store source folder metadata on imported `ImageRecord`s (`sourceRelativePath`, `sourceTopLevelFolder`)
- add an Import Folder action in `GalleryView` using macOS directory picker
- add dynamic `FOLDER CATEGORIES` in `CollectionsView` generated from imported folder metadata

## Why
Issue #12 requests that folder structure is respected when building the app image library and categories, while ensuring modifications occur only on copied library files.

## Notes
- existing drag/drop single-image import behavior is preserved
- folder categories are dynamic view groupings (approach A) and do not auto-create mutable `ImageCollection` records

## Validation plan
- run targeted project checks available in this environment and report results
- manual UI validation should confirm: import folder -> images copied under preserved subpaths -> categories show top-level folders
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caff9654-96c1-40cc-af79-bbafc1abc951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caff9654-96c1-40cc-af79-bbafc1abc951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

