### PR TITLE
Add configurable image library folder support

### DIFF
--- a/Wardrobe/Models/Navigation.swift
+++ b/Wardrobe/Models/Navigation.swift
@@ -11,6 +11,7 @@ enum NavigationSection: String, CaseIterable, Identifiable {
     case screenshots = "Screenshots"
     case collections = "Collections"
     case quickLinks = "Quick Links"
+    case settings = "Settings"
     case reOrganizer = "Re-Organizer"
     case spaceSaver = "Space Saver"
     case duplicateFinder = "Duplicate Finder"
@@ -22,6 +23,7 @@ enum NavigationSection: String, CaseIterable, Identifiable {
         case .screenshots: return "photo.on.rectangle"
         case .collections: return "folder"
         case .quickLinks: return "link"
+        case .settings: return "gearshape"
         case .reOrganizer: return "arrow.triangle.2.circlepath"
         case .spaceSaver: return "internaldrive"
         case .duplicateFinder: return "doc.on.doc"
@@ -30,7 +32,7 @@ enum NavigationSection: String, CaseIterable, Identifiable {
     
     var category: NavigationCategory {
         switch self {
-        case .screenshots, .collections, .quickLinks:
+        case .screenshots, .collections, .quickLinks, .settings:
             return .library
         case .reOrganizer, .spaceSaver, .duplicateFinder:
             return .tools

--- a/Wardrobe/Services/AppSettings.swift
+++ b/Wardrobe/Services/AppSettings.swift
@@ -1,0 +1,52 @@
+//
+//  AppSettings.swift
+//  Wardrobe
+//
+//  Created by Codex on 25/04/2026.
+//
+
+import Foundation
+
+enum AppSettings {
+    static let customImageLibraryPathKey = "customImageLibraryPath"
+    private static let defaultImageLibraryRelativePath = "Wardrobe/Images"
+    
+    static func imageLibraryURL(
+        fileManager: FileManager = .default,
+        userDefaults: UserDefaults = .standard
+    ) -> URL? {
+        if let customPath = userDefaults.string(forKey: customImageLibraryPathKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !customPath.isEmpty {
+            return URL(fileURLWithPath: customPath, isDirectory: true)
+        }
+        
+        guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        
+        return documentsURL.appendingPathComponent(defaultImageLibraryRelativePath, isDirectory: true)
+    }
+    
+    static func setCustomImageLibraryURL(
+        _ url: URL?,
+        userDefaults: UserDefaults = .standard
+    ) {
+        guard let url else {
+            userDefaults.removeObject(forKey: customImageLibraryPathKey)
+            return
+        }
+        
+        userDefaults.set(url.standardizedFileURL.path, forKey: customImageLibraryPathKey)
+    }
+    
+    static func customImageLibraryURL(userDefaults: UserDefaults = .standard) -> URL? {
+        guard let customPath = userDefaults.string(forKey: customImageLibraryPathKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !customPath.isEmpty else {
+            return nil
+        }
+        
+        return URL(fileURLWithPath: customPath, isDirectory: true)
+    }
+}

--- a/Wardrobe/Services/StorageManager.swift
+++ b/Wardrobe/Services/StorageManager.swift
@@ -18,29 +18,11 @@ struct ImportedImage {
 /// A background actor responsible for safely managing the local file system.
 ///
 /// `StorageManager` ensures that images dropped into the app are safely copied
-/// to the user's `~/Documents/Wardrobe/Images` directory without blocking the main UI thread.
+/// to the configured image library directory without blocking the main UI thread.
 actor StorageManager {
     /// The shared singleton instance.
     static let shared = StorageManager()
-    
-    private lazy var imagesDirectory: URL? = {
-        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            print("Error: Could not access Documents directory")
-            return nil
-        }
-        
-        let appDirectory = documentsURL.appendingPathComponent("Wardrobe/Images")
-        
-        do {
-            try FileManager.default.createDirectory(at: appDirectory, withIntermediateDirectories: true, attributes: nil)
-            print("Storage directory ready at: \(appDirectory.path)")
-            return appDirectory
-        } catch {
-            print("Error creating storage directory: \(error)")
-            return nil
-        }
-    }()
-    
+
     private init() {}
     
     /// Asynchronously copies an image from an `NSItemProvider` (e.g., from a Drag and Drop event)
@@ -50,9 +32,7 @@ actor StorageManager {
     /// - Returns: The absolute URL where the image was permanently saved.
     /// - Throws: `StorageError` if the directory is missing or the system fails to copy the file.
     func saveImage(from itemProvider: NSItemProvider) async throws -> URL {
-        guard let imagesDirectory else {
-            throw StorageError.directoryNotAvailable
-        }
+        let imagesDirectory = try resolveImageLibraryDirectory()
         
         let destinationURL = nextDestinationURL(in: imagesDirectory)
         
@@ -85,9 +65,7 @@ actor StorageManager {
     /// - Returns: The new absolute URL where the image was permanently saved.
     /// - Throws: `StorageError` if the directory is missing or the copy operation fails.
     func saveImage(from url: URL) throws -> URL {
-        guard let imagesDirectory else {
-            throw StorageError.directoryNotAvailable
-        }
+        let imagesDirectory = try resolveImageLibraryDirectory()
         
         let destinationURL = nextDestinationURL(in: imagesDirectory)
         try FileManager.default.copyItem(at: url, to: destinationURL)
@@ -101,9 +79,7 @@ actor StorageManager {
     /// - Returns: Imported image descriptors including copied file URL and source folder metadata.
     /// - Throws: `StorageError` if directory enumeration or file copy fails.
     func importImages(fromDirectory directoryURL: URL) throws -> [ImportedImage] {
-        guard let imagesDirectory else {
-            throw StorageError.directoryNotAvailable
-        }
+        let imagesDirectory = try resolveImageLibraryDirectory()
         
         let fileManager = FileManager.default
         let rootName = directoryURL.lastPathComponent
@@ -171,6 +147,23 @@ actor StorageManager {
         let uniqueSuffix = UUID().uuidString.prefix(6)
         let filename = "screenshot_\(timestamp)_\(uniqueSuffix).png"
         return directory.appendingPathComponent(filename)
+    }
+
+    private func resolveImageLibraryDirectory() throws -> URL {
+        guard let imageLibraryURL = AppSettings.imageLibraryURL() else {
+            throw StorageError.directoryNotAvailable
+        }
+        
+        do {
+            try FileManager.default.createDirectory(
+                at: imageLibraryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            return imageLibraryURL
+        } catch {
+            throw StorageError.copyFailed(error)
+        }
     }
 }
 

--- a/Wardrobe/Views/GalleryView.swift
+++ b/Wardrobe/Views/GalleryView.swift
@@ -525,9 +525,22 @@ struct GalleryView: View {
     }
     
     private func openImagesFolder() {
-        if let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let appDirectory = documentsURL.appendingPathComponent("Wardrobe/Images")
+        guard let appDirectory = AppSettings.imageLibraryURL() else {
+            errorMessage = "Storage directory is not available."
+            showingError = true
+            return
+        }
+        
+        do {
+            try FileManager.default.createDirectory(
+                at: appDirectory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
             NSWorkspace.shared.open(appDirectory)
+        } catch {
+            errorMessage = "Failed to open folder: \(error.localizedDescription)"
+            showingError = true
         }
     }
 }

--- a/Wardrobe/Views/MainContentView.swift
+++ b/Wardrobe/Views/MainContentView.swift
@@ -39,6 +39,8 @@ struct MainContentView: View {
             SpaceSaverView()
         case .duplicateFinder:
             DuplicateFinderView()
+        case .settings:
+            SettingsView()
         }
     }
 }

--- a/Wardrobe/Views/SettingsView.swift
+++ b/Wardrobe/Views/SettingsView.swift
@@ -1,0 +1,97 @@
+//
+//  SettingsView.swift
+//  Wardrobe
+//
+//  Created by Codex on 25/04/2026.
+//
+
+import SwiftUI
+import AppKit
+
+struct SettingsView: View {
+    @State private var customLibraryURL: URL? = AppSettings.customImageLibraryURL()
+    @State private var showingError = false
+    @State private var errorMessage: String?
+    
+    private var effectiveLibraryURL: URL? {
+        AppSettings.imageLibraryURL()
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("General")
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Image Library Folder")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Wardrobe copies uploaded images into this folder.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                
+                Text(effectiveLibraryURL?.path ?? "Unavailable")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                    .padding(.top, 2)
+                
+                HStack(spacing: 10) {
+                    Button("Choose Folder...") {
+                        chooseCustomLibraryFolder()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    
+                    Button("Use Default") {
+                        AppSettings.setCustomImageLibraryURL(nil)
+                        customLibraryURL = nil
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(customLibraryURL == nil)
+                }
+                .padding(.top, 2)
+            }
+            
+            Spacer()
+        }
+        .padding(20)
+        .frame(width: 520, height: 220)
+        .alert("Unable to set folder", isPresented: $showingError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage ?? "Unknown error.")
+        }
+    }
+    
+    private func chooseCustomLibraryFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Choose"
+        panel.message = "Select a folder to store imported screenshots."
+        panel.directoryURL = effectiveLibraryURL
+        
+        let response = panel.runModal()
+        guard response == .OK, let selectedURL = panel.url else { return }
+        
+        do {
+            try FileManager.default.createDirectory(
+                at: selectedURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            AppSettings.setCustomImageLibraryURL(selectedURL)
+            customLibraryURL = selectedURL.standardizedFileURL
+        } catch {
+            errorMessage = error.localizedDescription
+            showingError = true
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/Wardrobe/Views/SidebarView.swift
+++ b/Wardrobe/Views/SidebarView.swift
@@ -13,7 +13,7 @@ struct SidebarView: View {
     
     @Query private var allImages: [ImageRecord]
     
-    private let libraryItems: [NavigationSection] = [.screenshots, .collections, .quickLinks]
+    private let libraryItems: [NavigationSection] = [.screenshots, .collections, .quickLinks, .settings]
     private let toolItems: [NavigationSection] = [.reOrganizer, .spaceSaver, .duplicateFinder]
     
     var body: some View {

--- a/Wardrobe/WardrobeApp.swift
+++ b/Wardrobe/WardrobeApp.swift
@@ -42,6 +42,10 @@ struct WardrobeApp: App {
                 .modelContainer(modelContainer)
         }
         .menuBarExtraStyle(.window)
+        
+        Settings {
+            SettingsView()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared `AppSettings` helper to persist a custom image-library folder path (with default fallback to `~/Documents/Wardrobe/Images`)
- update `StorageManager` so all drag-drop saves and directory imports resolve the active library folder at runtime
- add a new `SettingsView` so users can choose a custom library folder or revert to the default
- wire app navigation and scene configuration to expose settings in both the sidebar and the macOS Settings window
- update gallery "Open folder" action to open the active configured library directory

## Testing
- `xcodebuild -project Wardrobe.xcodeproj -scheme Wardrobe -destination 'platform=macOS' build` *(fails in Linux cloud environment: `xcodebuild` unavailable)*
- `which xcodebuild || true; swift --version || true` *(confirms missing macOS Swift toolchain in this environment)*
- `xcrun --find xcodebuild || true; uname -a` *(confirms no Xcode tooling and Linux host)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94e7175d-954a-43d4-8280-36507a26b484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94e7175d-954a-43d4-8280-36507a26b484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

