### PR TITLE
Clarify Space Saver compression format in UI

### DIFF
--- a/Wardrobe/Views/SpaceSaverView.swift
+++ b/Wardrobe/Views/SpaceSaverView.swift
@@ -74,7 +74,7 @@ struct SpaceSaverView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("This will re-encode PNG screenshots as JPEG to save disk space. The originals cannot be restored afterwards.")
+            Text("This will re-encode PNG, TIFF, and BMP screenshots as JPEG (.jpg) to save disk space. The originals cannot be restored afterwards.")
         }
     }
     
@@ -83,7 +83,7 @@ struct SpaceSaverView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Space Saver")
                     .font(.system(size: 28, weight: .bold))
-                Text("Intelligent compression with 3 quality levels.")
+                Text("Converts PNG, TIFF, and BMP screenshots to compressed JPEG (.jpg) with 3 quality levels.")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }
@@ -241,6 +241,9 @@ struct SpaceSaverView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("\(compressibleImages.count) compressible images in library")
                 .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Text("Space Saver re-encodes PNG, TIFF, and BMP files as JPEG (.jpg). It keeps the original file only when JPEG would not save space.")
+                .font(.system(size: 11))
                 .foregroundStyle(.secondary)
             
             if isCompressing {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updated Space Saver header copy to explicitly say PNG/TIFF/BMP screenshots are converted to JPEG (`.jpg`).
- Updated the compression confirmation message to include all supported source formats and the output format.
- Added helper text in the action panel explaining that originals are only kept when JPEG would not reduce size.

## Testing
- `xcodebuild -project Wardrobe.xcodeproj -scheme Wardrobe -configuration Debug -sdk macosx build` *(fails in this Linux cloud environment because `xcodebuild` is unavailable)*

## Notes
- This addresses issue #10 by making compression behavior and output format explicit in the UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82e33231-338e-400f-9054-4fd37933d0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82e33231-338e-400f-9054-4fd37933d0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

