### PR TITLE
Fix Space Saver overwriting originals by using compressed folder

### DIFF
--- a/Wardrobe/Services/AppSettings.swift
+++ b/Wardrobe/Services/AppSettings.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AppSettings {
     static let customImageLibraryPathKey = "customImageLibraryPath"
     private static let defaultImageLibraryRelativePath = "Wardrobe/Images"
+    private static let compressedImageFolderName = "Compressed"
     
     static func imageLibraryURL(
         fileManager: FileManager = .default,
@@ -26,6 +27,14 @@ enum AppSettings {
         }
         
         return documentsURL.appendingPathComponent(defaultImageLibraryRelativePath, isDirectory: true)
+    }
+
+    static func compressedImageLibraryURL(
+        fileManager: FileManager = .default,
+        userDefaults: UserDefaults = .standard
+    ) -> URL? {
+        imageLibraryURL(fileManager: fileManager, userDefaults: userDefaults)?
+            .appendingPathComponent(compressedImageFolderName, isDirectory: true)
     }
     
     static func setCustomImageLibraryURL(

--- a/Wardrobe/Services/SpaceSaverService.swift
+++ b/Wardrobe/Services/SpaceSaverService.swift
@@ -62,8 +62,9 @@ actor SpaceSaverService {
     
     enum SpaceSaverError: Error {
         case imageLoadFailed
-        case bitmapCreationFailed
         case jpegEncodingFailed
+        case compressedDirectoryUnavailable
+        case compressedDirectoryCreationFailed(Error)
     }
     
     /// The result of a successful compression operation.
@@ -77,7 +78,7 @@ actor SpaceSaverService {
         var saved: Int64 { oldBytes - newBytes }
     }
     
-    /// Analyzes an image on disk and attempts to rewrite it using lossy JPEG compression.
+    /// Analyzes an image on disk and attempts to re-encode it using lossy JPEG compression.
     ///
     /// If the newly generated JPEG is larger than the original uncompressed file, the operation
     /// is discarded and the original file is kept to ensure no disk space is wasted.
@@ -109,21 +110,41 @@ actor SpaceSaverService {
             return CompressionResult(newURL: url, oldBytes: oldBytes, newBytes: oldBytes)
         }
         
-        let newURL = url
-            .deletingPathExtension()
-            .appendingPathExtension("jpg")
+        let compressedDirectory = try resolveCompressedImageDirectory()
+        let newURL = nextCompressedDestinationURL(for: url, in: compressedDirectory)
         
         try jpegData.write(to: newURL, options: .atomic)
-        
-        if newURL != url {
-            try? FileManager.default.removeItem(at: url)
-        }
         
         return CompressionResult(
             newURL: newURL,
             oldBytes: oldBytes,
             newBytes: Int64(jpegData.count)
         )
+    }
+
+    private func resolveCompressedImageDirectory() throws -> URL {
+        guard let compressedLibraryURL = AppSettings.compressedImageLibraryURL() else {
+            throw SpaceSaverError.compressedDirectoryUnavailable
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: compressedLibraryURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            return compressedLibraryURL
+        } catch {
+            throw SpaceSaverError.compressedDirectoryCreationFailed(error)
+        }
+    }
+
+    private func nextCompressedDestinationURL(for sourceURL: URL, in directory: URL) -> URL {
+        let baseName = sourceURL.deletingPathExtension().lastPathComponent
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let uniqueSuffix = UUID().uuidString.prefix(6)
+        let filename = "\(baseName)_compressed_\(timestamp)_\(uniqueSuffix).jpg"
+        return directory.appendingPathComponent(filename)
     }
     
     static func fileSize(at url: URL) -> Int64 {

--- a/Wardrobe/Views/SpaceSaverView.swift
+++ b/Wardrobe/Views/SpaceSaverView.swift
@@ -74,7 +74,7 @@ struct SpaceSaverView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("This will re-encode PNG, TIFF, and BMP screenshots as JPEG (.jpg) to save disk space. The originals cannot be restored afterwards.")
+            Text("This will re-encode PNG, TIFF, and BMP screenshots as JPEG (.jpg) in a separate Compressed folder. Original screenshots remain untouched.")
         }
     }
     
@@ -242,7 +242,7 @@ struct SpaceSaverView: View {
             Text("\(compressibleImages.count) compressible images in library")
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
-            Text("Space Saver re-encodes PNG, TIFF, and BMP files as JPEG (.jpg). It keeps the original file only when JPEG would not save space.")
+            Text("Space Saver writes compressed JPEG copies to a separate Compressed folder and keeps your original PNG, TIFF, and BMP screenshots.")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
             

--- a/WardrobeTests/AppSettingsTests.swift
+++ b/WardrobeTests/AppSettingsTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Wardrobe
+
+final class AppSettingsTests: XCTestCase {
+    func testCompressedImageLibraryURL_usesDefaultLibraryPath() {
+        let suiteName = "AppSettingsTests-\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test user defaults suite")
+            return
+        }
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        guard let imageLibraryURL = AppSettings.imageLibraryURL(userDefaults: userDefaults) else {
+            XCTFail("Expected default image library URL")
+            return
+        }
+        guard let compressedURL = AppSettings.compressedImageLibraryURL(userDefaults: userDefaults) else {
+            XCTFail("Expected compressed image library URL")
+            return
+        }
+
+        XCTAssertEqual(compressedURL, imageLibraryURL.appendingPathComponent("Compressed", isDirectory: true))
+    }
+
+    func testCompressedImageLibraryURL_usesCustomLibraryPath() {
+        let suiteName = "AppSettingsTests-\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test user defaults suite")
+            return
+        }
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("wardrobe-library-\(UUID().uuidString)", isDirectory: true)
+        AppSettings.setCustomImageLibraryURL(temporaryDirectory, userDefaults: userDefaults)
+
+        guard let compressedURL = AppSettings.compressedImageLibraryURL(userDefaults: userDefaults) else {
+            XCTFail("Expected compressed image library URL")
+            return
+        }
+
+        XCTAssertEqual(compressedURL, temporaryDirectory.appendingPathComponent("Compressed", isDirectory: true))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `AppSettings.compressedImageLibraryURL()` to resolve a dedicated `Compressed` subdirectory under the active image library path
- update `SpaceSaverService` to write JPEG outputs into that `Compressed` folder and never delete original screenshots
- refresh `SpaceSaverView` copy so the UI clearly states compression is now non-destructive
- add `AppSettingsTests` coverage for default and custom compressed-library path resolution

## Validation
- attempted to run `xcodebuild -project Wardrobe.xcodeproj -scheme Wardrobe -destination 'platform=macOS' test -only-testing:WardrobeTests/AppSettingsTests` (blocked in this Linux environment because `xcodebuild` is unavailable)
- verified compressed-directory wiring in `AppSettings`, `SpaceSaverService`, and `SpaceSaverView`
- verified `SpaceSaverService` no longer contains the original-file deletion call
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-468cebef-636a-4342-92ab-1d71ab17e0f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-468cebef-636a-4342-92ab-1d71ab17e0f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

