### PR TITLE
Fix gallery performance by downsampling thumbnails

### DIFF
--- a/Wardrobe/Views/GalleryView.swift
+++ b/Wardrobe/Views/GalleryView.swift
@@ -263,7 +263,8 @@ struct GalleryView: View {
                 ForEach(images, id: \.id) { image in
                     ImageCardView(
                         record: image,
-                        similarity: searchResults.first(where: { $0.record.id == image.id })?.similarity
+                        similarity: searchResults.first(where: { $0.record.id == image.id })?.similarity,
+                        thumbnailMaxPixelSize: zoomLevel * 2
                     )
                     .onTapGesture {
                         selectedImage = image

--- a/Wardrobe/Views/GalleryView.swift
+++ b/Wardrobe/Views/GalleryView.swift
@@ -37,6 +37,10 @@ struct GalleryView: View {
         }
         return searchResults.map { $0.record }
     }
+
+    private var similarityByImageID: [UUID: Double] {
+        Dictionary(uniqueKeysWithValues: searchResults.map { ($0.record.id, $0.similarity) })
+    }
     
     private var groupedImages: [(key: String, value: [ImageRecord])] {
         let calendar = Calendar.current
@@ -261,56 +265,65 @@ struct GalleryView: View {
                 spacing: 12
             ) {
                 ForEach(images, id: \.id) { image in
-                    ImageCardView(
-                        record: image,
-                        similarity: searchResults.first(where: { $0.record.id == image.id })?.similarity,
-                        thumbnailMaxPixelSize: zoomLevel * 2
-                    )
-                    .onTapGesture {
-                        selectedImage = image
-                    }
-                    .contextMenu {
-                        Button {
-                            QuickLookPreviewer.shared.preview(urls: [image.fileURL])
-                        } label: {
-                            Label("Quick Look", systemImage: "eye")
-                        }
-                        .keyboardShortcut(.space, modifiers: [])
-                        
-                        Button {
-                            NSWorkspace.shared.activateFileViewerSelecting([image.fileURL])
-                        } label: {
-                            Label("Show in Finder", systemImage: "folder")
-                        }
-                        
-                        if !allCollections.isEmpty {
-                            Menu {
-                                ForEach(allCollections) { collection in
-                                    let isMember = collection.images.contains { $0.id == image.id }
-                                    Button {
-                                        toggleMembership(image: image, collection: collection)
-                                    } label: {
-                                        Label(
-                                            collection.name,
-                                            systemImage: isMember ? "checkmark.circle.fill" : collection.iconName
-                                        )
-                                    }
-                                }
-                            } label: {
-                                Label("Add to Collection", systemImage: "folder.badge.plus")
-                            }
-                        }
-                        
-                        Divider()
-                        
-                        Button(role: .destructive) {
-                            deleteImage(image)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    }
+                    imageCard(for: image)
                 }
             }
+        }
+    }
+
+    private func imageCard(for image: ImageRecord) -> some View {
+        ImageCardView(
+            record: image,
+            similarity: similarityByImageID[image.id],
+            thumbnailMaxPixelSize: zoomLevel * 2
+        )
+        .onTapGesture {
+            selectedImage = image
+        }
+        .contextMenu {
+            imageContextMenu(for: image)
+        }
+    }
+
+    @ViewBuilder
+    private func imageContextMenu(for image: ImageRecord) -> some View {
+        Button {
+            QuickLookPreviewer.shared.preview(urls: [image.fileURL])
+        } label: {
+            Label("Quick Look", systemImage: "eye")
+        }
+        .keyboardShortcut(.space, modifiers: [])
+
+        Button {
+            NSWorkspace.shared.activateFileViewerSelecting([image.fileURL])
+        } label: {
+            Label("Show in Finder", systemImage: "folder")
+        }
+
+        if !allCollections.isEmpty {
+            Menu {
+                ForEach(allCollections) { collection in
+                    let isMember = collection.images.contains { $0.id == image.id }
+                    Button {
+                        toggleMembership(image: image, collection: collection)
+                    } label: {
+                        Label(
+                            collection.name,
+                            systemImage: isMember ? "checkmark.circle.fill" : collection.iconName
+                        )
+                    }
+                }
+            } label: {
+                Label("Add to Collection", systemImage: "folder.badge.plus")
+            }
+        }
+
+        Divider()
+
+        Button(role: .destructive) {
+            deleteImage(image)
+        } label: {
+            Label("Delete", systemImage: "trash")
         }
     }
     

--- a/Wardrobe/Views/ImageCardView.swift
+++ b/Wardrobe/Views/ImageCardView.swift
@@ -12,7 +12,7 @@ import ImageIO
 struct ImageCardView: View {
     let record: ImageRecord
     let similarity: Double?
-    let thumbnailMaxPixelSize: CGFloat = 320
+    let thumbnailMaxPixelSize: CGFloat
     
     @State private var image: NSImage?
     @State private var loadedThumbnailPixelSize: Int?
@@ -32,6 +32,16 @@ struct ImageCardView: View {
         cache.countLimit = 500
         return cache
     }()
+
+    init(
+        record: ImageRecord,
+        similarity: Double?,
+        thumbnailMaxPixelSize: CGFloat = 320
+    ) {
+        self.record = record
+        self.similarity = similarity
+        self.thumbnailMaxPixelSize = thumbnailMaxPixelSize
+    }
     
     var body: some View {
         ZStack(alignment: .topTrailing) {

--- a/Wardrobe/Views/ImageCardView.swift
+++ b/Wardrobe/Views/ImageCardView.swift
@@ -198,9 +198,11 @@ struct ImageCardView: View {
         let imageURL = record.fileURL
         loadingTask = Task.detached(priority: .userInitiated) {
             guard let nsImage = Self.makeThumbnail(from: imageURL, maxPixelSize: pixelSize) else { return }
+            guard !Task.isCancelled else { return }
             Self.thumbnailCache.setObject(nsImage, forKey: key)
             
             await MainActor.run {
+                guard pixelSize >= self.requestedThumbnailPixelSize else { return }
                 self.image = nsImage
                 self.loadedThumbnailPixelSize = pixelSize
             }

--- a/Wardrobe/Views/ImageCardView.swift
+++ b/Wardrobe/Views/ImageCardView.swift
@@ -12,7 +12,7 @@ import ImageIO
 struct ImageCardView: View {
     let record: ImageRecord
     let similarity: Double?
-    let thumbnailMaxPixelSize: CGFloat
+    let thumbnailMaxPixelSize: CGFloat = 320
     
     @State private var image: NSImage?
     @State private var loadedThumbnailPixelSize: Int?
@@ -23,8 +23,8 @@ struct ImageCardView: View {
         max(180, Int(thumbnailMaxPixelSize.rounded(.up)))
     }
     
-    private var cacheKey: NSString {
-        "\(record.fileURL.path)#\(requestedThumbnailPixelSize)" as NSString
+    private var cacheKeyString: String {
+        "\(record.fileURL.path)#\(requestedThumbnailPixelSize)"
     }
     
     private static let thumbnailCache: NSCache<NSString, NSImage> = {
@@ -186,8 +186,9 @@ struct ImageCardView: View {
             return
         }
         
-        let key = cacheKey
-        if let cached = Self.thumbnailCache.object(forKey: key) {
+        let keyString = cacheKeyString
+        let cacheLookupKey = NSString(string: keyString)
+        if let cached = Self.thumbnailCache.object(forKey: cacheLookupKey) {
             image = cached
             loadedThumbnailPixelSize = pixelSize
             return
@@ -196,20 +197,22 @@ struct ImageCardView: View {
         loadingTask?.cancel()
         
         let imageURL = record.fileURL
+        let cacheStoreKeyString = keyString
         loadingTask = Task.detached(priority: .userInitiated) {
             guard let nsImage = Self.makeThumbnail(from: imageURL, maxPixelSize: pixelSize) else { return }
             guard !Task.isCancelled else { return }
-            Self.thumbnailCache.setObject(nsImage, forKey: key)
             
             await MainActor.run {
                 guard pixelSize >= self.requestedThumbnailPixelSize else { return }
+                let cacheStoreKey = NSString(string: cacheStoreKeyString)
+                Self.thumbnailCache.setObject(nsImage, forKey: cacheStoreKey)
                 self.image = nsImage
                 self.loadedThumbnailPixelSize = pixelSize
             }
         }
     }
     
-    private static func makeThumbnail(from url: URL, maxPixelSize: Int) -> NSImage? {
+    private nonisolated static func makeThumbnail(from url: URL, maxPixelSize: Int) -> NSImage? {
         let sourceOptions: [CFString: Any] = [
             kCGImageSourceShouldCache: false
         ]

--- a/Wardrobe/Views/ImageCardView.swift
+++ b/Wardrobe/Views/ImageCardView.swift
@@ -7,13 +7,31 @@
 
 import SwiftUI
 import AppKit
+import ImageIO
 
 struct ImageCardView: View {
     let record: ImageRecord
     let similarity: Double?
+    let thumbnailMaxPixelSize: CGFloat
     
     @State private var image: NSImage?
+    @State private var loadedThumbnailPixelSize: Int?
+    @State private var loadingTask: Task<Void, Never>?
     @State private var isHovered = false
+    
+    private var requestedThumbnailPixelSize: Int {
+        max(180, Int(thumbnailMaxPixelSize.rounded(.up)))
+    }
+    
+    private var cacheKey: NSString {
+        "\(record.fileURL.path)#\(requestedThumbnailPixelSize)" as NSString
+    }
+    
+    private static let thumbnailCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 500
+        return cache
+    }()
     
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -31,6 +49,13 @@ struct ImageCardView: View {
             .padding(8)
         }
         .onAppear(perform: loadImage)
+        .onChange(of: requestedThumbnailPixelSize) { _, newSize in
+            loadImageIfNeeded(for: newSize)
+        }
+        .onDisappear {
+            loadingTask?.cancel()
+            loadingTask = nil
+        }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -153,16 +178,59 @@ struct ImageCardView: View {
     }
     
     private func loadImage() {
-        guard image == nil else { return }
-        let url = record.fileURL
+        loadImageIfNeeded(for: requestedThumbnailPixelSize)
+    }
+    
+    private func loadImageIfNeeded(for pixelSize: Int) {
+        if let loadedThumbnailPixelSize, loadedThumbnailPixelSize >= pixelSize, image != nil {
+            return
+        }
         
-        Task.detached(priority: .userInitiated) {
-            guard let data = try? Data(contentsOf: url),
-                  let nsImage = NSImage(data: data) else { return }
+        let key = cacheKey
+        if let cached = Self.thumbnailCache.object(forKey: key) {
+            image = cached
+            loadedThumbnailPixelSize = pixelSize
+            return
+        }
+        
+        loadingTask?.cancel()
+        
+        let imageURL = record.fileURL
+        loadingTask = Task.detached(priority: .userInitiated) {
+            guard let nsImage = Self.makeThumbnail(from: imageURL, maxPixelSize: pixelSize) else { return }
+            Self.thumbnailCache.setObject(nsImage, forKey: key)
+            
             await MainActor.run {
                 self.image = nsImage
+                self.loadedThumbnailPixelSize = pixelSize
             }
         }
+    }
+    
+    private static func makeThumbnail(from url: URL, maxPixelSize: Int) -> NSImage? {
+        let sourceOptions: [CFString: Any] = [
+            kCGImageSourceShouldCache: false
+        ]
+        
+        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, sourceOptions as CFDictionary) else {
+            return nil
+        }
+        
+        let thumbnailOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, thumbnailOptions as CFDictionary) else {
+            return nil
+        }
+        
+        return NSImage(
+            cgImage: thumbnail,
+            size: NSSize(width: thumbnail.width, height: thumbnail.height)
+        )
     }
     
     private func timeAgoString(from date: Date) -> String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace full-image decoding in `ImageCardView` with ImageIO thumbnail downsampling
- add an in-memory thumbnail cache keyed by file path and target thumbnail size
- pass gallery zoom-driven pixel target into each card so thumbnails scale with UI density
- keep `ImageCardView` source-compatible via an explicit initializer with a default thumbnail size so both 2-arg and 3-arg call sites compile
- guard async thumbnail tasks from applying stale results after zoom changes
- break large `GalleryView` image-card/context-menu expression into smaller helpers to resolve Swift type-checker timeout

## Testing
- `xcodebuild -project Wardrobe.xcodeproj -scheme Wardrobe build` *(blocked in cloud Linux environment: `xcodebuild: command not found`)*

Fixes #7
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61fbb90a-f140-4952-9eba-44a22b1f5c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61fbb90a-f140-4952-9eba-44a22b1f5c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

